### PR TITLE
Warnung für veraltete vehicle tokens vermeiden

### DIFF
--- a/lib/teslaResponse.js
+++ b/lib/teslaResponse.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Tesla product and vehicle responses may contain a `tokens` property. These
+ * values are deprecated vehicle tokens and must not be mirrored into ioBroker
+ * states, because the adapter intentionally deletes the legacy token object.
+ *
+ * @param {unknown} payload Tesla response object or response array.
+ * @returns {unknown} The same payload instance without shallow `tokens` keys.
+ */
+function removeVehicleTokens(payload) {
+  if (Array.isArray(payload)) {
+    for (const entry of payload) {
+      removeVehicleTokens(entry);
+    }
+    return payload;
+  }
+
+  if (payload && typeof payload === 'object') {
+    delete payload.tokens;
+  }
+
+  return payload;
+}
+
+module.exports = {
+  removeVehicleTokens,
+};

--- a/main.js
+++ b/main.js
@@ -10,6 +10,7 @@ const {
   FleetTelemetryConfigurationManager,
   isFleetTelemetryAdminCommand,
 } = require('./lib/fleetTelemetryConfig');
+const { removeVehicleTokens } = require('./lib/teslaResponse');
 
 // Fleet API regional endpoints (like HA const.py:17-18)
 const FLEET_API_REGIONS = {
@@ -443,6 +444,7 @@ class Teslamotors extends utils.Adapter {
       headers: this.getFleetHeaders(),
     })
       .then(async (res) => {
+        removeVehicleTokens(res.data && res.data.response);
         this.log.debug(JSON.stringify(res.data));
 
         this.idArray = [];
@@ -660,7 +662,10 @@ class Teslamotors extends utils.Adapter {
           this.delObjectAsync(
             this.name + '.' + this.instance + '.' + id + '.remote.set_scheduled_departure-scheduled_departure',
           );
-          this.delObject(id + '.tokens', { recursive: true });
+          // Clean up the legacy token object once, but never recreate it from
+          // the current Fleet API response. Otherwise js-controller reports
+          // "State ...tokens has no existing object" on later updates.
+          await this.delObjectAsync(id + '.tokens', { recursive: true }).catch(() => {});
         }
       })
       .catch(async (error) => {
@@ -921,6 +926,7 @@ class Teslamotors extends utils.Adapter {
       const url = this.getFleetApiBaseUrl() + '/api/1/vehicles/' + vin + '/charge_history';
       const res = await this.requestClient({ method: 'post', url: url, headers: this.getFleetHeaders() });
       if (res.data && res.data.response) {
+        removeVehicleTokens(res.data.response);
         const data = res.data.response;
         if (data.charging_history_graph) {
           delete data.charging_history_graph.y_labels;
@@ -966,9 +972,7 @@ class Teslamotors extends utils.Adapter {
         url: fleetBase + '/api/1/vehicles/' + vin,
         headers: headers,
       });
-      if (stateRes.data.response && stateRes.data.response.tokens) {
-        delete stateRes.data.response.tokens;
-      }
+      removeVehicleTokens(stateRes.data && stateRes.data.response);
       this.json2iob.parse(vin, stateRes.data.response, { preferedArrayName: 'timestamp' });
       state = stateRes.data.response.state;
       this.log.debug(vin + ' state check response keys: ' + Object.keys(stateRes.data.response || {}).join(', '));
@@ -1107,7 +1111,7 @@ class Teslamotors extends utils.Adapter {
         });
         return;
       }
-      if (res.data.response.tokens) delete res.data.response.tokens;
+      removeVehicleTokens(res.data && res.data.response);
 
       const data = res.data.response;
       const dataKeys = Object.keys(data);
@@ -1242,9 +1246,9 @@ class Teslamotors extends utils.Adapter {
         headers: headers,
       })
         .then((res) => {
+          removeVehicleTokens(res.data && res.data.response);
           this.log.debug(JSON.stringify(res.data));
           if (!res.data) return;
-          if (res.data.response && res.data.response.tokens) delete res.data.response.tokens;
 
           const data = res.data.response;
           const preferedArrayName = 'timestamp';
@@ -1328,7 +1332,7 @@ class Teslamotors extends utils.Adapter {
         headers: this.getFleetHeaders(),
       });
       if (!res.data) return;
-      if (res.data.response && res.data.response.tokens) delete res.data.response.tokens;
+      removeVehicleTokens(res.data && res.data.response);
       this.json2iob.parse(vin, res.data.response);
     } catch (error) {
       if (error.response && (error.response.status >= 500 || error.response.status === 408)) {
@@ -1502,8 +1506,8 @@ class Teslamotors extends utils.Adapter {
       this.log.debug(JSON.stringify(data));
       return await this.requestClient({ method: 'post', url: url, headers: headers, data: data })
         .then((res) => {
+          removeVehicleTokens(res.data && res.data.response);
           this.log.info(JSON.stringify(res.data));
-          if (res.data.response && res.data.response.tokens) delete res.data.response.tokens;
           return res.data.response;
         })
         .catch((error) => {
@@ -1527,8 +1531,8 @@ class Teslamotors extends utils.Adapter {
       this.log.debug(url);
       return await this.requestClient({ method: 'post', url: url, headers: headers })
         .then((res) => {
+          removeVehicleTokens(res.data && res.data.response);
           this.log.info(JSON.stringify(res.data));
-          if (res.data.response && res.data.response.tokens) delete res.data.response.tokens;
           return res.data.response;
         })
         .catch((error) => {

--- a/teslaResponse.test.js
+++ b/teslaResponse.test.js
@@ -1,0 +1,70 @@
+'use strict';
+
+const { expect } = require('chai');
+const { removeVehicleTokens } = require('./lib/teslaResponse');
+
+describe('Tesla response sanitizing', () => {
+  it('removes deprecated vehicle tokens from product list entries before state parsing', () => {
+    const products = [
+      {
+        vin: 'VIN123',
+        display_name: 'Vehicle',
+        tokens: ['legacy-token-a', 'legacy-token-b'],
+      },
+      {
+        id: 'SITE123',
+        site_name: 'Powerwall',
+        tokens: ['legacy-site-token'],
+      },
+    ];
+
+    const result = removeVehicleTokens(products);
+
+    expect(result).to.equal(products);
+    expect(products[0]).to.not.have.property('tokens');
+    expect(products[1]).to.not.have.property('tokens');
+    expect(products[0]).to.include({ vin: 'VIN123', display_name: 'Vehicle' });
+    expect(products[1]).to.include({ id: 'SITE123', site_name: 'Powerwall' });
+  });
+
+  it('removes shallow tokens from a single vehicle response without touching other data', () => {
+    const response = {
+      id: 123,
+      vin: 'VIN123',
+      state: 'online',
+      tokens: ['legacy-token'],
+      vehicle_state: {
+        locked: true,
+        tokens: ['nested-value-is-not-a-state-root-token'],
+      },
+    };
+
+    removeVehicleTokens(response);
+
+    expect(response).to.not.have.property('tokens');
+    expect(response.vehicle_state).to.deep.equal({
+      locked: true,
+      tokens: ['nested-value-is-not-a-state-root-token'],
+    });
+  });
+
+  it('ignores empty responses', () => {
+    expect(removeVehicleTokens(null)).to.equal(null);
+    expect(removeVehicleTokens(undefined)).to.equal(undefined);
+  });
+
+  it('keeps empty arrays unchanged', () => {
+    const products = [];
+
+    const result = removeVehicleTokens(products);
+
+    expect(result).to.equal(products);
+    expect(products).to.deep.equal([]);
+  });
+
+  it('keeps scalar payloads unchanged', () => {
+    expect(removeVehicleTokens(42)).to.equal(42);
+    expect(removeVehicleTokens('online')).to.equal('online');
+    expect(removeVehicleTokens(true)).to.equal(true);
+  });
+});


### PR DESCRIPTION
## Zusammenfassung

Dieser PR verhindert, dass das veraltete Tesla-Feld `tokens` aus Product-/Vehicle-Responses als ioBroker-State gespiegelt wird.

Damit wird die Warnung aus #355 behoben:

> State `tesla-motors.<VIN>.tokens` has no existing object, this might lead to an error in future versions

## Ursache

`json2iob` cached bereits angelegte Objekte zur Laufzeit. Wenn `<VIN>.tokens` nachträglich gelöscht wird, der Cache das Objekt aber noch als vorhanden kennt, kann beim nächsten Update ein `setState` auf ein nicht mehr existierendes Objekt erfolgen.

## Änderung

- Neuer Helper `removeVehicleTokens(...)`, der top-level `tokens` aus Tesla-Responses entfernt.
- Bereinigung erfolgt vor `json2iob.parse(...)`, damit die States gar nicht erst erzeugt bzw. erneut gecached werden.
- Bestehende Legacy-Objekte `<VIN>.tokens` werden weiterhin einmalig aufgeräumt.
- Zusätzliche Tests für Arrays, einzelne Responses, leere/scalare Payloads und bewusst nicht rekursive Bereinigung.

## Tests

- `npm test` ✅
- `npm run lint -- .` ✅

Hinweis: `npm run check` schlägt aktuell unabhängig von diesem PR bereits auf `upstream/master` wegen `TS5107` / `moduleResolution=node10` fehl. Das ist nicht Teil dieses Fixes.

Closes #355
