### PR TITLE
chore: altes Changelog nicht veröffentlichen

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "io-package.json",
     "main.js",
     "README.md",
-    "CHANGELOG_OLD.md",
     "LICENSE"
   ]
 }


### PR DESCRIPTION
## Zusammenfassung

Dieser Mini-PR adressiert den letzten Repository-Checker-Hinweis aus #356:

- `S9508`: `CHANGELOG_OLD.md` ist über `package.json#files` im npm-Paket enthalten.

Die Datei bleibt im Repository erhalten, wird aber nicht mehr ins npm-Paket aufgenommen.

## Validierung

- `npm run lint`
- `npm test`
- `npm run check`
- `NPM_CONFIG_CACHE=/private/tmp/npm-cache-tesla npm pack --dry-run`

Bezug: #356
