### PR TITLE
docs: Sentry-Hinweis exakt standardkonform formulieren

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ All Tesla vehicles and Powerwalls from the Tesla App are displayed and updated v
 
 Vehicle commands (lock, unlock, climate, charging, etc.) are supported for all models including post-2021 vehicles that require **end-to-end command signing** (Vehicle Command Protocol).
 
-This adapter uses Sentry libraries to automatically report exceptions and code errors to the developers. For more details and for information on how to disable the error reporting, see [Sentry-Plugin Documentation](https://github.com/ioBroker/plugin-sentry#plugin-sentry)! Sentry reporting is used starting with js-controller 3.0.
+**This adapter uses Sentry libraries to automatically report exceptions and code errors to the developers.** For more details and for information on how to disable the error reporting, see [Sentry-Plugin Documentation](https://github.com/ioBroker/plugin-sentry#plugin-sentry)! Sentry reporting is used starting with js-controller 3.0.
 
 ### Requirements
 


### PR DESCRIPTION
## Zusammenfassung

- Sentry-Hinweis im README exakt an die vom `ioBroker.repochecker` erwartete Standardformulierung angepasst
- erster Satz jetzt inklusive Markdown-Hervorhebung wie im aktuellen Repochecker-Check erwartet
- keine funktionalen Änderungen

## Hintergrund

Der Repository-Checker hatte weiterhin W6023 gemeldet, obwohl der Hinweis bereits im oberen README-Bereich stand. Die aktuelle Repochecker-Logik akzeptiert u. a. exakt diese Formulierung:

```markdown
**This adapter uses Sentry libraries to automatically report exceptions and code errors to the developers.**
```

## Validierung

- Lokaler Regex-Abgleich gegen die Repochecker-Erwartung: erfolgreich
- `npm run lint -- --quiet`: erfolgreich
- Claude-Review: keine Blocker, Änderung als risikoarm bewertet
