### PR TITLE
GitHub-Workflow für externe Antworten ergänzen

### DIFF
--- a/.github/workflows/clear-wait-for-feedback.yml
+++ b/.github/workflows/clear-wait-for-feedback.yml
@@ -1,0 +1,61 @@
+name: Clear wait-for-feedback on external response
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+
+jobs:
+  clear-label:
+    name: Remove wait-for-feedback label
+    runs-on: ubuntu-latest
+    steps:
+      - name: Remove label after external response
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const labelName = 'wait for feedback';
+            const maintainerAssociations = new Set(['OWNER', 'MEMBER', 'COLLABORATOR']);
+            const comment = context.payload.comment;
+            const issue = context.payload.issue;
+
+            if (!comment || !issue) {
+              core.info('No issue or comment payload found. Nothing to do.');
+              return;
+            }
+
+            if (comment.user?.type === 'Bot') {
+              core.info(`Comment author ${comment.user.login} is a bot. Keeping label unchanged.`);
+              return;
+            }
+
+            if (maintainerAssociations.has(comment.author_association)) {
+              core.info(
+                `Comment author ${comment.user.login} has association ${comment.author_association}. Keeping label unchanged.`,
+              );
+              return;
+            }
+
+            const hasWaitForFeedbackLabel = (issue.labels || []).some((label) => label.name === labelName);
+            if (!hasWaitForFeedbackLabel) {
+              core.info(`Issue/PR #${issue.number} does not have label "${labelName}". Nothing to do.`);
+              return;
+            }
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                name: labelName,
+              });
+              core.info(`Removed label "${labelName}" from issue/PR #${issue.number} after external response.`);
+            } catch (error) {
+              if (error.status === 404) {
+                core.info(`Label "${labelName}" was already absent from issue/PR #${issue.number}.`);
+                return;
+              }
+              throw error;
+            }


### PR DESCRIPTION
## Zusammenfassung

Dieser PR ergänzt einen kleinen GitHub-Workflow, der das Label `wait for feedback` automatisch entfernt, sobald eine externe Person auf ein Issue oder einen Pull Request antwortet.

## Verhalten

- Trigger: neuer Issue-/PR-Kommentar (`issue_comment.created`)
- Entfernt `wait for feedback`, wenn der Kommentar von einer externen Person kommt
- Ignoriert Kommentare von `OWNER`, `MEMBER` und `COLLABORATOR`
- Ignoriert Bot-Kommentare, damit Automationen wie Repository-Checker-Kommentare das Label nicht versehentlich entfernen
- Funktioniert für Issues und Pull Requests, da PR-Labels über die Issues-API verwaltet werden

## Prüfung

- YAML-Datei lokal syntaktisch mit Ruby/Psych geladen
