### PR TITLE
release-script auf 5.2.1 aktualisieren

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "iobroker.tesla-motors",
-  "version": "3.0.0",
+  "version": "3.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "iobroker.tesla-motors",
-      "version": "3.0.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@iobroker/adapter-core": "^3.3.2",
@@ -18,7 +18,7 @@
         "qs": "^6.15.1"
       },
       "devDependencies": {
-        "@alcalzone/release-script": "^5.2.0",
+        "@alcalzone/release-script": "^5.2.1",
         "@alcalzone/release-script-plugin-iobroker": "^5.2.0",
         "@alcalzone/release-script-plugin-license": "^5.2.0",
         "@alcalzone/release-script-plugin-manual-review": "^5.2.0",
@@ -60,14 +60,14 @@
       }
     },
     "node_modules/@alcalzone/release-script": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alcalzone/release-script/-/release-script-5.2.0.tgz",
-      "integrity": "sha512-ClpLHZJM8CIqRAokcjVI7FcX2Vf6hIGSmHociY4AmRtGrcYpeQJA7dBel8bPLEkCQvTED+9NiBiAKXF5xUpXtw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@alcalzone/release-script/-/release-script-5.2.1.tgz",
+      "integrity": "sha512-d7aeYU/c1fKcBRkZGpfLLAK6zjpOPV00NzdsYKap9uTdlBqrC5d/OlY7n9Jet0eKTzygKsz7mtPlV8t5GNPGPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alcalzone/release-script-core": "5.2.0",
-        "@alcalzone/release-script-plugin-changelog": "5.2.0",
+        "@alcalzone/release-script-plugin-changelog": "5.2.1",
         "@alcalzone/release-script-plugin-exec": "5.2.0",
         "@alcalzone/release-script-plugin-git": "5.2.0",
         "@alcalzone/release-script-plugin-package": "5.2.0",
@@ -100,9 +100,9 @@
       }
     },
     "node_modules/@alcalzone/release-script-plugin-changelog": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alcalzone/release-script-plugin-changelog/-/release-script-plugin-changelog-5.2.0.tgz",
-      "integrity": "sha512-ImLQDrn/EUFdGBBh+/auyMVDAKQOhZqKWwDNTmc/bniHjPZrKUjVKcSaXcNDQMiuPOL+Lw2yqwCyg9AM50+SGw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@alcalzone/release-script-plugin-changelog/-/release-script-plugin-changelog-5.2.1.tgz",
+      "integrity": "sha512-IUbwNQW6r5O40FUKGz3yHumnca6o8Xct/d4+7wslkcjnBMbUR5CMlt0/QCi/Xs9jNhumvLV9w7pNkku2WCz/xg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8687,13 +8687,13 @@
       }
     },
     "@alcalzone/release-script": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alcalzone/release-script/-/release-script-5.2.0.tgz",
-      "integrity": "sha512-ClpLHZJM8CIqRAokcjVI7FcX2Vf6hIGSmHociY4AmRtGrcYpeQJA7dBel8bPLEkCQvTED+9NiBiAKXF5xUpXtw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@alcalzone/release-script/-/release-script-5.2.1.tgz",
+      "integrity": "sha512-d7aeYU/c1fKcBRkZGpfLLAK6zjpOPV00NzdsYKap9uTdlBqrC5d/OlY7n9Jet0eKTzygKsz7mtPlV8t5GNPGPg==",
       "dev": true,
       "requires": {
         "@alcalzone/release-script-core": "5.2.0",
-        "@alcalzone/release-script-plugin-changelog": "5.2.0",
+        "@alcalzone/release-script-plugin-changelog": "5.2.1",
         "@alcalzone/release-script-plugin-exec": "5.2.0",
         "@alcalzone/release-script-plugin-git": "5.2.0",
         "@alcalzone/release-script-plugin-package": "5.2.0",
@@ -8716,9 +8716,9 @@
       }
     },
     "@alcalzone/release-script-plugin-changelog": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/@alcalzone/release-script-plugin-changelog/-/release-script-plugin-changelog-5.2.0.tgz",
-      "integrity": "sha512-ImLQDrn/EUFdGBBh+/auyMVDAKQOhZqKWwDNTmc/bniHjPZrKUjVKcSaXcNDQMiuPOL+Lw2yqwCyg9AM50+SGw==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@alcalzone/release-script-plugin-changelog/-/release-script-plugin-changelog-5.2.1.tgz",
+      "integrity": "sha512-IUbwNQW6r5O40FUKGz3yHumnca6o8Xct/d4+7wslkcjnBMbUR5CMlt0/QCi/Xs9jNhumvLV9w7pNkku2WCz/xg==",
       "dev": true,
       "requires": {
         "@alcalzone/release-script-core": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "qs": "^6.15.1"
   },
   "devDependencies": {
-    "@alcalzone/release-script": "^5.2.0",
+    "@alcalzone/release-script": "^5.2.1",
     "@alcalzone/release-script-plugin-iobroker": "^5.2.0",
     "@alcalzone/release-script-plugin-license": "^5.2.0",
     "@alcalzone/release-script-plugin-manual-review": "^5.2.0",


### PR DESCRIPTION
## Zusammenfassung

- `@alcalzone/release-script` von `^5.2.0` auf `^5.2.1` aktualisiert.
- `package-lock.json` entsprechend aktualisiert.
- Nebenbei die veraltete Root-Version im Lockfile auf `3.2.0` synchronisiert, da `npm install --package-lock-only` diese Metadaten korrigiert hat.

## Hintergrund

Der ioBroker-Repository-Checker im Stable-PR meldet aktuell `E0036`, weil mindestens `@alcalzone/release-script` `5.2.1` erwartet wird.

## Validierung

- `npm run lint`
- `npm test`
- `npm run check`

