### PR TITLE
Remove dead dependency badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 [![Downloads](https://img.shields.io/npm/dm/iobroker.tesla-motors.svg)](https://www.npmjs.com/package/iobroker.tesla-motors)
 ![Number of Installations (latest)](https://iobroker.live/badges/tesla-motors-installed.svg)
 ![Number of Installations (stable)](https://iobroker.live/badges/tesla-motors-stable.svg)
-[![Dependency Status](https://img.shields.io/david/iobroker-community-adapters/iobroker.tesla-motors.svg)](https://david-dm.org/iobroker-community-adapters/iobroker.tesla-motors)
 
 [![NPM](https://nodei.co/npm/iobroker.tesla-motors.png?downloads=true)](https://nodei.co/npm/iobroker.tesla-motors/)
 


### PR DESCRIPTION
## Zusammenfassung

Entfernt den nicht mehr auflösbaren `david-dm.org`/`img.shields.io/david` Dependency-Status-Badge aus der README.

## Hintergrund

Der Badge-Dienst wird nicht mehr zuverlässig bedient und erzeugt dadurch einen kaputten Badge in der README. Die übrigen npm-, Installations- und Test-Badges bleiben unverändert erhalten.

## Prüfung

- `npm run check`
